### PR TITLE
Fixed broken link to author's github profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To make `MIT Alloy` the default highlighting for the current extension:
 
 + [http://corb.co](http://corb.co)
 + [http://twitter.com/corbco](http://twitter.com/corbco)
-+ [http://github.com/corbanmailloux](http://github.com/corbco)
++ [http://github.com/corbanmailloux](https://github.com/corbanmailloux)
 
 
 ## Copyright and License


### PR DESCRIPTION
this was referring to github.com/corbco and 404'ing
